### PR TITLE
Avoid the use of the "freenet:"-prefix.

### DIFF
--- a/src/plugins/Library/client/FreenetArchiver.java
+++ b/src/plugins/Library/client/FreenetArchiver.java
@@ -147,7 +147,7 @@ implements LiveArchiver<T, SimpleProgress>, RequestClient {
 		if(task.meta instanceof FreenetURI) {
 			u = (FreenetURI) task.meta;
 			initialMetadata = null;
-			cacheKey = u.toASCIIString();
+			cacheKey = u.toString(false, true);
 		} else {
 			initialMetadata = (byte[]) task.meta;
 			u = FreenetURI.EMPTY_CHK_URI;
@@ -344,7 +344,7 @@ implements LiveArchiver<T, SimpleProgress>, RequestClient {
 					} else if(status == WAIT_STATUS.GENERATED_URI) {
 						FreenetURI uri = cb.getURI();
 						task.meta = uri;
-						cacheKey = uri.toASCIIString();
+						cacheKey = uri.toString(false, true);
 						System.out.println("Got URI for asynchronous insert: "+uri+" size "+tempB.size()+" in "+(System.currentTimeMillis() - cb.startTime));
 					} else {
 						Bucket data = cb.getGeneratedMetadata();


### PR DESCRIPTION
In some cases, when the FreenetArchiver works from an URI instead of from
an encoded number, files are created with the URI name. This does not work
on windows because colon ":" is not allowed by the file system.

This fix creates and uses the filenames without the freenet:-prefix in
those cases, not changing the more common case.

This is an attempt to fix https://bugs.freenetproject.org/view.php?id=5986.
