### PR TITLE
Fix NullPointerException on old or negative USK edition

### DIFF
--- a/src/plugins/Library/index/xml/XMLIndex.java
+++ b/src/plugins/Library/index/xml/XMLIndex.java
@@ -193,7 +193,7 @@ public class XMLIndex implements Index, ClientGetCallback {
 				} else {
 					if(logMINOR) Logger.minor(this, "Trying new URI: "+e.newURI+" : "+indexuri);
 					startFetch(true);
-					if(updateHook != null)
+					if(updateHook != null && updateContext != null)
 						updateHook.update(updateContext, indexuri);
 					return;
 				}


### PR DESCRIPTION
When searching in an unbookmarked XML index using an old or negative USK
edition, Library throws NullPointerException.

Relayed for [KingSloth on FMS](http://127.0.0.1:8888/SSK%40kSloth%7ESrrdJfe8qoumuiY7tWSVOpQav7usAwMB7PqE%2CJJRmnrN1EoxLcwsmAEpVa%7EMkygHBs8orW4QEud9CCG4%2CAQACAAE/fms%7C2016%2D06%2D15%7CMessage%2D2?type=text/plain).

Please review.
